### PR TITLE
issue 9：pool socket files exceed umlimit max

### DIFF
--- a/src/backend/pgxc/pool/poolmgr.c
+++ b/src/backend/pgxc/pool/poolmgr.c
@@ -2428,10 +2428,14 @@ PoolerLoop(void)
 					ereport(LOG,
 							(errcode(ERRCODE_CONNECTION_FAILURE), errmsg("pool manager failed to accept connection: %m")));
 					errno = saved_errno;
-					return;
+					if (saved_errno == EMFILE || saved_errno == ENFILE) {
+						 pg_usleep(100000L);
+					} else {
+						return;
+					}
+				} else {
+					agent_create(new_fd);
 				}
-
-				agent_create(new_fd);
 			}
 		}
 	}


### PR DESCRIPTION
在pooler进程accept失败时：检查错误码，如果是进程句柄数达到上限或是系统句柄数到达上限，则休眠0.1秒，醒来后继续监听pooler进程的domain socket，进入下一次循环；如果是其他错误码，则退出。
